### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = "OpenJDK Runtime Environment"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Alien Chase 2013 Chema Edition
 
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/alienchase-gdx)](https://repl.it/github/UzayAnil/alienchase-gdx)
 ProTip: this README file is written in plain English. Most of the code for
 this project is still in Spanish. I don't know if I'll translate the code
 to English, as this is just some sample code that owns to my tutorials,


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@UzayAnil/alienchase-gdx).